### PR TITLE
Using Subspecs to Modularize Application Support

### DIFF
--- a/MWOpenInKit.podspec
+++ b/MWOpenInKit.podspec
@@ -10,5 +10,44 @@ Pod::Spec.new do |s|
   s.platform  = :ios, '7.0'
 
   s.source_files = 'MWOpenInKit', 'MWOpenInKit/**/*.{h,m}'
-  s.resource_bundles = { 'MWOpenInKit' => "MWOpenInKit/**/*.{plist,png}" }
+
+  s.subspec 'Browsers' do |ss|
+    ss.subspec 'Chrome' do |sss|
+      sss.resource_bundles = { 'MWOpenInKit' => "MWOpenInKit/Apps/Chrome/*.{plist,png}" }
+    end
+
+    ss.subspec 'Safari' do |sss|
+      sss.resource_bundles = { 'MWOpenInKit' => "MWOpenInKit/Apps/Safari/*.{plist,png}" }
+    end
+  end
+
+  s.subspec 'Maps' do |ss|
+    ss.subspec 'Google Maps' do |sss|
+      sss.resource_bundles = { 'MWOpenInKit' => "MWOpenInKit/Apps/Google Maps/*.{plist,png}" }
+    end
+
+    ss.subspec 'Maps' do |sss|
+      sss.resource_bundles = { 'MWOpenInKit' => "MWOpenInKit/Apps/Maps/*.{plist,png}" }
+    end
+  end
+
+  s.subspec 'Passwords' do |ss|
+    ss.subspec '1Password' do |sss|
+      sss.resource_bundles = { 'MWOpenInKit' => "MWOpenInKit/Apps/1Password/*.{plist,png}" }
+    end
+  end
+
+  s.subspec 'Twitter' do |ss|
+    ss.subspec 'Tweetbot' do |sss|
+      sss.resource_bundles = { 'MWOpenInKit' => "MWOpenInKit/Apps/Tweetbot/*.{plist,png}" }
+    end
+
+    ss.subspec 'Twitter' do |sss|
+      sss.resource_bundles = { 'MWOpenInKit' => "MWOpenInKit/Apps/Twitter/*.{plist,png}" }
+    end
+
+    ss.subspec 'Twitterrific' do |sss|
+      sss.resource_bundles = { 'MWOpenInKit' => "MWOpenInKit/Apps/Twitterrific/*.{plist,png}" }
+    end
+  end
 end


### PR DESCRIPTION
Although the current set of applications is pretty manageable at the moment, it will eventually become excessive to include every application with every install (those icon files really add up).

Cocoapods subspecs offer an elegant way to modularize out functionality, allowing the consumer to specify only what they need. The proposed patch organizes apps into top level groups, representing intents, and then a sub-subspec for each individual application. This allows for the following:
#### Podfile

``` ruby
pod 'MWOpenInKit' # Works the same as before
pod 'MWOpenInKit/Twitter' # Only include Twitter apps
pod 'MWOpenInKit/Twitter/Tweetbot' # Only include Tweetbot
```

I still have a few lingering concerns that I'd like to get some feedback on:
1. Categorizing sets an important precedent. It's important to make sure the way everything is named and carved up is something we won't eventually regret.
2. This could be further spec'd out to only include relevant handlers for each category. The correct relationship between these categories and handlers would be something to dwell upon. 
3. CocoaPods 0.23.0 introduced [the `resource_bundle` method](https://github.com/0xced/HockeySDK-iOS/commit/9602890751209b7884382eea9a6acf5e364480b3), which is perfect for this purpose, but seems to lack the first-class support `resources` does. If we run `pod lint` on this, we get:

```
- ERROR | [iOS] The MWOpenInKit/Browsers/Chrome (0.1.0) spec is empty (no source files, resources, preserve paths, , vendored_libraries, vendored_frameworks dependencies or sub specs).
```

This is either something Cocoapods still needs to implement, or I could be misunderstanding how this feature should work.
