### PR TITLE
Fixed Twitter URL scheme for mentions

### DIFF
--- a/IntentKit/Apps/Twitter/Twitter.plist
+++ b/IntentKit/Apps/Twitter/Twitter.plist
@@ -15,7 +15,7 @@
 		<key>showTimeline</key>
 		<string>twitter://timeline</string>
 		<key>showMentions</key>
-		<string>twitter://connect</string>
+		<string>twitter://mentions</string>
 		<key>showDirectMessages</key>
 		<string>twitter://connect</string>
 		<key>searchFor:</key>


### PR DESCRIPTION
Updated URL scheme sends users to Notifications tab in Twitter.app. Partial fix for issue #1.
