### PR TITLE
sendDirectMessageToScreenName:

### DIFF
--- a/IntentKit/Apps/Defaults/INKTwitterHandler.plist
+++ b/IntentKit/Apps/Defaults/INKTwitterHandler.plist
@@ -16,6 +16,8 @@
 		<string>https://twitter.com/i/connect</string>
 		<key>showDirectMessages</key>
 		<string>https://twitter.com/i/connect</string>
+		<key>sendDirectMessageToScreenName:</key>
+		<string>https://mobile.twitter.com/{screenName}/messages</string>
 		<key>searchFor:</key>
 		<string>https://twitter.com/search?q={query}</string>
 		<key>tweetMessage:</key>

--- a/IntentKit/Apps/Twitter/Twitter.plist
+++ b/IntentKit/Apps/Twitter/Twitter.plist
@@ -18,6 +18,8 @@
 		<string>twitter://mentions</string>
 		<key>showDirectMessages</key>
 		<string>twitter://connect</string>
+		<key>sendDirectMessageToScreenName:</key>
+		<string>twitter://messages?screen_name={screenName}</string>
 		<key>searchFor:</key>
 		<string>twitter://search?query={query}</string>
 		<key>tweetMessage:</key>

--- a/IntentKit/Handlers/INKTwitterHandler.h
+++ b/IntentKit/Handlers/INKTwitterHandler.h
@@ -53,6 +53,11 @@
  @warning The first-party Twitter app does not have a "Messages" screen any more. If this results in opening Twitter.app, the "Connect" page will be displayed, which aggregates @mentions, DMs, and favorites/retweets/etc. */
 - (INKActivityPresenter *)showDirectMessages;
 
+/** Opens a window to compose a new DM / view DMs for a given user.
+ @param screenName A screen name to search for
+ @return A `INKActivityPresenter` object to present. */
+-(INKActivityPresenter *)sendDirectMessageToScreenName:(NSString *)screenName;
+
 /** Searches for tweets or users
  @param query A string to search for
  @return A `INKActivityPresenter` object to present. */

--- a/IntentKit/Handlers/INKTwitterHandler.m
+++ b/IntentKit/Handlers/INKTwitterHandler.m
@@ -125,6 +125,10 @@
                   withArguments:[self argumentsDictionaryWithArguments:NSDictionaryOfVariableBindings(tweetId)]];
 }
 
+- (INKActivityPresenter *)sendDirectMessageToScreenName:(NSString *)screenName {
+    return [self performCommand:NSStringFromSelector(_cmd) withArguments:NSDictionaryOfVariableBindings(screenName)];
+}
+
 #pragma mark - Private methods
 - (NSDictionary *)argumentsDictionaryWithArguments:(NSDictionary *)args {
     if (!args) {


### PR DESCRIPTION
Added for Twitter.app and web fallback. Closes #30.
