### PR TITLE
Use NSBundle bundleForClass in place of mainBundle

### DIFF
--- a/IntentKit/Core/INKApplicationList.m
+++ b/IntentKit/Core/INKApplicationList.m
@@ -128,7 +128,7 @@ static NSString * const FirstPartyAppNameKey = @"firstPartyAppName";
 }
 
 - (NSDictionary *)handlerDefaults {
-    NSURL *bundleURL = [[NSBundle mainBundle] URLForResource:@"IntentKit-Defaults" withExtension:@"bundle"];
+    NSURL *bundleURL = [[NSBundle bundleForClass:[INKApplicationList class]] URLForResource:@"IntentKit-Defaults" withExtension:@"bundle"];
     NSBundle *bundle;
     if (bundleURL) {
         bundle = [NSBundle bundleWithURL:bundleURL];
@@ -140,21 +140,21 @@ static NSString * const FirstPartyAppNameKey = @"firstPartyAppName";
 
 - (NSBundle *)bundleForCurrentHandler {
     NSString *resourceName = [NSString stringWithFormat:@"IntentKit-%@", NSStringFromClass(self.handlerClass)];
-    NSURL *bundleURL = [[NSBundle mainBundle] URLForResource:resourceName withExtension:@"bundle"];
+    NSURL *bundleURL = [[NSBundle bundleForClass:[INKApplicationList class]] URLForResource:resourceName withExtension:@"bundle"];
     NSBundle *bundle;
     if (bundleURL) {
         bundle = [NSBundle bundleWithURL:bundleURL];
     }
 
     if (!bundle) {
-        NSURL *bundleURL = [[NSBundle mainBundle] URLForResource:@"IntentKit" withExtension:@"bundle"];
+        NSURL *bundleURL = [[NSBundle bundleForClass:[INKApplicationList class]] URLForResource:@"IntentKit" withExtension:@"bundle"];
         if (bundleURL) {
             bundle = [NSBundle bundleWithURL:bundleURL];
         }
     }
 
     if (!bundle) {
-        bundle = [NSBundle mainBundle];
+        bundle = [NSBundle bundleForClass:[INKApplicationList class]];
     }
     
     return bundle;

--- a/IntentKit/Core/INKDefaultsManager.m
+++ b/IntentKit/Core/INKDefaultsManager.m
@@ -20,7 +20,7 @@ static NSString * const INKDefaultsManagerUserDefaultsKey = @"IntentKitDefaults"
     if (name) {
         return name;
     } else if (allowSystemDefault) {
-        NSURL *bundleURL = [[NSBundle mainBundle] URLForResource:@"IntentKit-Defaults" withExtension:@"bundle"];
+        NSURL *bundleURL = [[NSBundle bundleForClass:[INKDefaultsManager class]] URLForResource:@"IntentKit-Defaults" withExtension:@"bundle"];
         NSBundle *bundle;
         if (bundleURL) {
             bundle = [NSBundle bundleWithURL:bundleURL];

--- a/IntentKit/Core/INKLocalizedString.m
+++ b/IntentKit/Core/INKLocalizedString.m
@@ -7,6 +7,7 @@
 //
 
 #import "INKLocalizedString.h"
+#import "IntentKit.h"
 
 NSString *INKLocalizedString(NSString *key, NSString *comment) {
     NSString *result = @"";
@@ -14,7 +15,7 @@ NSString *INKLocalizedString(NSString *key, NSString *comment) {
     static NSBundle *bundle = nil;
     if (bundle == nil)
     {
-        NSString *bundlePath = [[NSBundle mainBundle] pathForResource:@"IntentKit-Localizations" ofType:@"bundle"];
+        NSString *bundlePath = [[NSBundle bundleForClass:[IntentKit class]] pathForResource:@"IntentKit-Localizations" ofType:@"bundle"];
         bundle = [NSBundle bundleWithPath:bundlePath];
         
         NSString *language = [[NSLocale preferredLanguages] count]? [NSLocale preferredLanguages][0]: @"en";
@@ -30,6 +31,6 @@ NSString *INKLocalizedString(NSString *key, NSString *comment) {
         bundle = [NSBundle bundleWithPath:bundlePath] ?: [NSBundle mainBundle];
     }
     result = [bundle localizedStringForKey:key value:result table:nil];
-    return [[NSBundle mainBundle] localizedStringForKey:key value:result table:nil];
+    return [[NSBundle bundleForClass:[IntentKit class]] localizedStringForKey:key value:result table:nil];
 
 };

--- a/IntentKit/Core/IntentKit.m
+++ b/IntentKit/Core/IntentKit.m
@@ -50,7 +50,7 @@
 }
 
 - (UIImage *)imageNamed:(NSString *)name {
-    NSURL *bundleURL = [[NSBundle mainBundle] URLForResource:@"IntentKit" withExtension:@"bundle"];
+    NSURL *bundleURL = [[NSBundle bundleForClass:[IntentKit class]] URLForResource:@"IntentKit" withExtension:@"bundle"];
     NSBundle *bundle;
     if (bundleURL) {
         bundle  = [NSBundle bundleWithURL:bundleURL];


### PR DESCRIPTION
[NSBundle mainBundle] fails to get IntentKit bundle resources when INK is used as a Cocoapod in a swift project. use of e.g. [NSBundle bundleForClass:[IntentKit class]] solves this problem. 

Tested with Swift and Obj C projects with INK as a a Cocoapod.