### PR TITLE
Include IntentKit-Localizations.bundle as podspec core resource

### DIFF
--- a/IntentKit.podspec
+++ b/IntentKit.podspec
@@ -12,9 +12,9 @@ Pod::Spec.new do |s|
   s.subspec 'Core' do |ss|
     ss.source_files = 'IntentKit', 'IntentKit/Core/**/*.{h,m}', "IntentKit/Handlers/INKBrowserHandler.{h,m}", 'IntentKit/Apps/INKWebView/*.{h,m}'
     ss.dependency "MWLayoutHelpers"
+    ss.resources = 'IntentKit/IntentKit-Localizations.bundle'
     ss.resource_bundles = { 'IntentKit' => 'IntentKit/{**/*.strings,Images/*.png}',
                             'IntentKit-Defaults' => "IntentKit/Apps/Defaults/*.{plist,png}",
-                            'IntentKit-Localizations' => "IntentKit/IntentKit-Localizations.bundle",
                             'IntentKit-INKBrowserHandler' => "IntentKit/Apps/{Chrome,Safari,1Password,INKWebView}/*.{plist,png}" }
     ss.requires_arc = true
   end

--- a/IntentKit.podspec
+++ b/IntentKit.podspec
@@ -12,8 +12,9 @@ Pod::Spec.new do |s|
   s.subspec 'Core' do |ss|
     ss.source_files = 'IntentKit', 'IntentKit/Core/**/*.{h,m}', "IntentKit/Handlers/INKBrowserHandler.{h,m}", 'IntentKit/Apps/INKWebView/*.{h,m}'
     ss.dependency "MWLayoutHelpers"
-    ss.resource_bundles = { 'IntentKit' => 'IntentKit/{**/*.strings,*.bundle,Images/*.png}',
-                            'IntentKit-Defaults' => "IntentKit/Apps/Defaults/*.{plist,png}",  
+    ss.resource_bundles = { 'IntentKit' => 'IntentKit/{**/*.strings,Images/*.png}',
+                            'IntentKit-Defaults' => "IntentKit/Apps/Defaults/*.{plist,png}",
+                            'IntentKit-Localizations' => "IntentKit/IntentKit-Localizations.bundle",
                             'IntentKit-INKBrowserHandler' => "IntentKit/Apps/{Chrome,Safari,1Password,INKWebView}/*.{plist,png}" }
     ss.requires_arc = true
   end

--- a/IntentKit.podspec
+++ b/IntentKit.podspec
@@ -5,15 +5,15 @@ Pod::Spec.new do |s|
   s.summary   = "An easier way to handle third-party URL schemes in iOS apps."
   s.homepage  = 'https://github.com/intentkit/IntentKit'
   s.authors   = { 'Mike Walker' => 'michael@lazerwalker.com' }
-  s.source    = { :git => 'https://github.com/intentkit/IntentKit.git', :tag => "0.7.1" }
+  s.source    = { :git => 'https://github.com/intentkit/IntentKit.git', :tag => "0.7.2" }
   s.requires_arc = true
   s.platform  = :ios, '7.0'
 
   s.subspec 'Core' do |ss|
     ss.source_files = 'IntentKit', 'IntentKit/Core/**/*.{h,m}', "IntentKit/Handlers/INKBrowserHandler.{h,m}", 'IntentKit/Apps/INKWebView/*.{h,m}'
     ss.dependency "MWLayoutHelpers"
-    ss.resource_bundles = { 'IntentKit' => 'IntentKit/{**/*.strings,Images/*.png}',
-                            'IntentKit-Defaults' => "IntentKit/Apps/Defaults/*.{plist,png}",
+    ss.resource_bundles = { 'IntentKit' => 'IntentKit/{**/*.strings,*.bundle,Images/*.png}',
+                            'IntentKit-Defaults' => "IntentKit/Apps/Defaults/*.{plist,png}",  
                             'IntentKit-INKBrowserHandler' => "IntentKit/Apps/{Chrome,Safari,1Password,INKWebView}/*.{plist,png}" }
     ss.requires_arc = true
   end

--- a/IntentKit/Core/Helpers/NSString+Helpers.h
+++ b/IntentKit/Core/Helpers/NSString+Helpers.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2013 Mike Walker. All rights reserved.
 //
 
-NSString *(^ink_urlEncode)(NSString *);
+extern NSString *(^ink_urlEncode)(NSString *);
 
 @interface NSString (Helpers)
 

--- a/IntentKit/Core/INKAppIconView.m
+++ b/IntentKit/Core/INKAppIconView.m
@@ -7,7 +7,7 @@
 //
 
 #import "INKAppIconView.h"
-#import <UIView+MWLayoutHelpers.h>
+#import "UIView+MWLayoutHelpers.h"
 #import "IntentKit.h"
 
 CGFloat const INKActivityCellIconSize_Pad = 76.f;

--- a/IntentKit/Core/INKAppIconView.m
+++ b/IntentKit/Core/INKAppIconView.m
@@ -7,7 +7,7 @@
 //
 
 #import "INKAppIconView.h"
-#import "UIView+MWLayoutHelpers.h"
+#import <MWLayoutHelpers/UIView+MWLayoutHelpers.h>
 #import "IntentKit.h"
 
 CGFloat const INKActivityCellIconSize_Pad = 76.f;

--- a/IntentKit/Core/INKDefaultsViewController/INKDefaultsCell.m
+++ b/IntentKit/Core/INKDefaultsViewController/INKDefaultsCell.m
@@ -12,7 +12,7 @@
 #import "INKApplicationList.h"
 #import "INKAppIconView.h"
 
-#import <UIView+MWLayoutHelpers.h>
+#import "UIView+MWLayoutHelpers.h"
 
 @interface INKDefaultsCell ()
 @property (readwrite, assign, nonatomic) BOOL isUsingFallback;

--- a/IntentKit/Core/INKDefaultsViewController/INKDefaultsCell.m
+++ b/IntentKit/Core/INKDefaultsViewController/INKDefaultsCell.m
@@ -12,7 +12,7 @@
 #import "INKApplicationList.h"
 #import "INKAppIconView.h"
 
-#import "UIView+MWLayoutHelpers.h"
+#import <MWLayoutHelpers/UIView+MWLayoutHelpers.h>
 
 @interface INKDefaultsCell ()
 @property (readwrite, assign, nonatomic) BOOL isUsingFallback;


### PR DESCRIPTION
In swift, the INKLocalizedString cannot access  IntentKit-Localizations.bundle if its not loaded as a resource in the podspec