### PR TITLE
Fixed import of MWLayoutHelpers in INKDefaultsCell and INKAppIconView and duplicate symbols for ink_urlEncode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ cache: cocoapods
 xcode_workspace: IntentKitDemo.xcworkspace
 xcode_scheme: IntentKitDemo
 xcode_sdk: iphonesimulator
+rvm:
+  - 2.2.2
 
 before_install:
   - gem install cocoapods slather activesupport -N

--- a/IntentKit/Core/Helpers/NSString+Helpers.h
+++ b/IntentKit/Core/Helpers/NSString+Helpers.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2013 Mike Walker. All rights reserved.
 //
 
-NSString *(^ink_urlEncode)(NSString *);
+extern NSString *(^ink_urlEncode)(NSString *);
 
 @interface NSString (Helpers)
 

--- a/IntentKit/Core/INKAppIconView.m
+++ b/IntentKit/Core/INKAppIconView.m
@@ -7,7 +7,7 @@
 //
 
 #import "INKAppIconView.h"
-#import <UIView+MWLayoutHelpers.h>
+#import <MWLayoutHelpers/UIView+MWLayoutHelpers.h>
 #import "IntentKit.h"
 
 CGFloat const INKActivityCellIconSize_Pad = 76.f;

--- a/IntentKit/Core/INKDefaultsViewController/INKDefaultsCell.m
+++ b/IntentKit/Core/INKDefaultsViewController/INKDefaultsCell.m
@@ -12,7 +12,7 @@
 #import "INKApplicationList.h"
 #import "INKAppIconView.h"
 
-#import <UIView+MWLayoutHelpers.h>
+#import <MWLayoutHelpers/UIView+MWLayoutHelpers.h>
 
 @interface INKDefaultsCell ()
 @property (readwrite, assign, nonatomic) BOOL isUsingFallback;


### PR DESCRIPTION
Fixed import of MWLayoutHelpers in INKAppIconView.m and INKDefaultsCell.m, 
Other files with this import are already fixed.

Also fixed compiler error: duplicate symbols for ink_urlEncode